### PR TITLE
chore(deps): enable Dependabot for npm weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"                # root of your project
+    schedule:
+      interval: weekly            # or "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
This pull request introduces a Dependabot configuration file to automate dependency updates for the project.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R9): Added a configuration file to enable weekly automated dependency updates for the `npm` package ecosystem, with a limit of five open pull requests and a commit message prefix of "chore".