### PR TITLE
chore(ci): use PAT to push to gh-pages for deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
           git fetch origin gh-pages || echo "No gh-pages branch yet"
           git checkout gh-pages || git checkout --orphan gh-pages
           git reset --hard
-          # Copy built files from dist to root
-          cp -r dist/* .
+          # Copy built files from dist to root (including hidden files)
+          cp -r dist/.* dist/* .
           git add -A
           git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
-          git push origin gh-pages
+          git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           # Verify if 'dist' exists and copy the files
           if [ -d "dist" ]; then
             cp -r dist/* . || echo "No visible files to copy"
-            cp -r dist/.* . 2>/dev/null || echo "No hidden files to copy"
+            find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \; || echo "No hidden files to copy"
             git add -A
             git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
             git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
             cp -r dist/* . || echo "No visible files to copy"
             find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \; || echo "No hidden files to copy"
             git add -A
-            git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
+            # Check if there are changes before committing
+            if ! git diff --cached --quiet; then
+              git commit -m "Deploy to GitHub Pages"
+            else
+              echo "No changes to commit"
+            fi
+            # Push to gh-pages with error handling
             git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }
-          else
-            echo "Error: dist directory does not exist. Build may have failed."
-            exit 1
-          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,35 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git fetch origin gh-pages || echo "No gh-pages branch yet"
-          git checkout gh-pages || git checkout --orphan gh-pages
+
+          # Check if the gh-pages branch exists
+          if git rev-parse --verify gh-pages >/dev/null 2>&1; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+          fi
+
           git reset --hard
+
           # Verify if 'dist' exists and copy the files
           if [ -d "dist" ]; then
             cp -r dist/* . || echo "No visible files to copy"
+
+            # Copy hidden files (e.g., .htaccess) from the 'dist' directory to ensure all necessary files are deployed
             find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \; || echo "No hidden files to copy"
+
             git add -A
+
             # Check if there are changes before committing
             if ! git diff --cached --quiet; then
               git commit -m "Deploy to GitHub Pages"
             else
               echo "No changes to commit"
             fi
+
             # Push to gh-pages with error handling
             git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }
+          else
+            echo "Error: 'dist' directory not found. Deployment aborted."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Build
         run: npm run build
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/Coraa-12/habit-builder.git
+          git push origin gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         run: |
+          set -e  # Exit immediately if any command fails
+
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
@@ -58,32 +60,18 @@ jobs:
 
           git reset --hard
 
-          # Verify if 'dist' exists and copy the files
-          if [ -d "dist" ]; then
-            # Copy visible files
-            if ! cp -r dist/* .; then
-              echo "Error: Failed to copy visible files from 'dist' directory."
-              exit 1
-            fi
-
-            # Verify if 'dist' exists and copy the files using rsync
-            if [ -d "dist" ]; then
-              # Copy all files (including hidden ones) with rsync
-              if ! rsync -a dist/ ./; then
-                echo "Error: Failed to copy files from 'dist' directory."
-                exit 1
-              fi
-
-            git add -A
-
-            # Check if there are changes before committing
-            if ! git diff --cached --quiet; then
-              git commit -m "Deploy to GitHub Pages"
-              git push origin gh-pages --force || { echo "Error: Failed to push to gh-pages"; exit 1; }
-            else
-              echo "No changes to commit"
-            fi
-          else
-            echo "Error: 'dist' directory not found. Deployment aborted."
+          # Copy all files (including hidden ones) with rsync
+          if ! rsync -a dist/ ./; then
+            echo "Error: Failed to copy files from 'dist' directory."
             exit 1
+          fi
+
+          git add -A
+
+          # Check if there are changes before committing
+          if ! git diff --cached --quiet; then
+            git commit -m "Deploy to GitHub Pages"
+            git push origin gh-pages --force || { echo "Error: Failed to push to gh-pages"; exit 1; }
+          else
+            echo "No changes to commit"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Validate Build Output
+        run: |
+          if [ ! -d "dist" ]; then
+            echo "Error: Build did not produce the dist directory."
+            exit 1
+          fi
+
       - name: Deploy to GitHub Pages
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -36,8 +44,14 @@ jobs:
           git fetch origin gh-pages || echo "No gh-pages branch yet"
           git checkout gh-pages || git checkout --orphan gh-pages
           git reset --hard
-          # Copy built files from dist to root (including hidden files)
-          cp -r dist/.* dist/* .
-          git add -A
-          git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
-          git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }
+          # Verify if 'dist' exists and copy the files
+          if [ -d "dist" ]; then
+            cp -r dist/* . || echo "No visible files to copy"
+            cp -r dist/.* . 2>/dev/null || echo "No hidden files to copy"
+            git add -A
+            git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
+            git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }
+          else
+            echo "Error: dist directory does not exist. Build may have failed."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
           # Check if the gh-pages branch exists
           if git rev-parse --verify gh-pages >/dev/null 2>&1; then
             git checkout gh-pages
-            git pull origin gh-pages --rebase || true
+            if ! git pull origin gh-pages --rebase; then
+              echo "Error: Failed to rebase the gh-pages branch."
+              exit 1
+            fi
           else
             git checkout --orphan gh-pages
           fi
@@ -63,11 +66,13 @@ jobs:
               exit 1
             fi
 
-            # Copy hidden files (e.g., .htaccess) from the 'dist' directory to ensure all necessary files are deployed
-            if ! find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \;; then
-              echo "Error: Failed to copy hidden files from 'dist' directory."
-              exit 1
-            fi
+            # Verify if 'dist' exists and copy the files using rsync
+            if [ -d "dist" ]; then
+              # Copy all files (including hidden ones) with rsync
+              if ! rsync -a dist/ ./; then
+                echo "Error: Failed to copy files from 'dist' directory."
+                exit 1
+              fi
 
             git add -A
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
             exit 1
           fi
 
+      - name: List dist contents
+        run: ls -la dist || echo "dist directory not found"
+
       - name: Deploy to GitHub Pages
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -45,6 +48,7 @@ jobs:
           # Check if the gh-pages branch exists
           if git rev-parse --verify gh-pages >/dev/null 2>&1; then
             git checkout gh-pages
+            git pull origin gh-pages --rebase || true
           else
             git checkout --orphan gh-pages
           fi
@@ -53,22 +57,27 @@ jobs:
 
           # Verify if 'dist' exists and copy the files
           if [ -d "dist" ]; then
-            cp -r dist/* . || echo "No visible files to copy"
+            # Copy visible files
+            if ! cp -r dist/* .; then
+              echo "Error: Failed to copy visible files from 'dist' directory."
+              exit 1
+            fi
 
             # Copy hidden files (e.g., .htaccess) from the 'dist' directory to ensure all necessary files are deployed
-            find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \; || echo "No hidden files to copy"
+            if ! find dist -mindepth 1 -maxdepth 1 -name ".*" ! -name "." ! -name ".." -exec cp -r {} . \;; then
+              echo "Error: Failed to copy hidden files from 'dist' directory."
+              exit 1
+            fi
 
             git add -A
 
             # Check if there are changes before committing
             if ! git diff --cached --quiet; then
               git commit -m "Deploy to GitHub Pages"
+              git push origin gh-pages --force || { echo "Error: Failed to push to gh-pages"; exit 1; }
             else
               echo "No changes to commit"
             fi
-
-            # Push to gh-pages with error handling
-            git push origin gh-pages || { echo "Error: Failed to push to gh-pages"; exit 1; }
           else
             echo "Error: 'dist' directory not found. Deployment aborted."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,11 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/Coraa-12/habit-builder.git
+          git fetch origin gh-pages || echo "No gh-pages branch yet"
+          git checkout gh-pages || git checkout --orphan gh-pages
+          git reset --hard
+          # Copy built files from dist to root
+          cp -r dist/* .
+          git add -A
+          git commit -m "Deploy to GitHub Pages" || echo "No changes to commit"
           git push origin gh-pages


### PR DESCRIPTION
This pull request updates the deployment process in the CI workflow to enhance security and provide more control over deployment credentials.

### CI Workflow Changes:
* Updated the deployment step in `.github/workflows/ci.yml` to replace the `peaceiris/actions-gh-pages` action with a custom script. This change uses a personal access token (`ACTIONS_DEPLOY_KEY`) instead of the default GitHub token, improving security and flexibility.- Set up GitHub Actions workflow to run on push and pull requests to main branch
- Install dependencies, lint, test, and build the project using Node.js 18
- Deploy build output to GitHub Pages using a deploy key