### PR TITLE
Fix GitHub Pages deployment with proper base path and configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Create .nojekyll file
+        run: touch dist/.nojekyll
+
       - name: Validate Build Output
         run: |
           if [ ! -d "dist" ]; then

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Svelte</title>
+    <title>Habit Builder</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
-// https://vite.dev/config/
+// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  base: "/habit-builder/", // Add this line for GitHub Pages
 })


### PR DESCRIPTION
This pull request includes updates to support deployment on GitHub Pages and minor project adjustments. The key changes involve modifying the build process, updating paths and metadata in `index.html`, and configuring the Vite project for GitHub Pages.

### Deployment support for GitHub Pages:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R35): Added a step to create a `.nojekyll` file in the `dist` directory to ensure proper handling of files by GitHub Pages.
* [`vite.config.js`](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L4-R7): Configured the `base` property to `/habit-builder/` to set the correct base path for GitHub Pages deployment.

### Updates to project metadata and paths:
* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L5-R11): Updated the favicon and script paths to use relative paths (`./vite.svg` and `./src/main.js`) and changed the page title from "Vite + Svelte" to "Habit Builder" to reflect the project's purpose.